### PR TITLE
Move pathschanged to separate package

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/drone/drone-go/plugin/converter"
 	"github.com/kanopy-platform/drone-extension-router/internal/plugin"
+	"github.com/kanopy-platform/drone-extension-router/internal/plugin/convert/pathschanged"
 	"github.com/kanopy-platform/drone-extension-router/internal/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -63,7 +64,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	}
 
 	if viper.GetBool("pathschanged-enabled") {
-		convertPlugins = append(convertPlugins, plugin.NewPathsChanged())
+		convertPlugins = append(convertPlugins, pathschanged.New())
 	}
 
 	log.Printf("Starting server on %s\n", addr)

--- a/internal/plugin/convert/pathschanged/pathschanged.go
+++ b/internal/plugin/convert/pathschanged/pathschanged.go
@@ -1,18 +1,18 @@
-package plugin
+package pathschanged
 
 import (
 	"context"
 
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/drone-go/plugin/converter"
-	pathschanged "github.com/meltwater/drone-convert-pathschanged/plugin"
+	"github.com/meltwater/drone-convert-pathschanged/plugin"
 )
 
 type PathsChanged struct {
 	provider string
 }
 
-func NewPathsChanged() *PathsChanged {
+func New() *PathsChanged {
 	return &PathsChanged{
 		provider: "github",
 	}
@@ -21,7 +21,7 @@ func NewPathsChanged() *PathsChanged {
 func (p *PathsChanged) Convert(ctx context.Context, req *converter.Request) (*drone.Config, error) {
 	// TODO: this type can be removed once the upstream pathschanged
 	// plugin supports reading the drone token directly
-	plugin := pathschanged.New(p.provider, &pathschanged.Params{Token: req.Token.Access})
+	plugin := plugin.New(p.provider, &plugin.Params{Token: req.Token.Access})
 
 	return plugin.Convert(ctx, req)
 }

--- a/internal/plugin/pathschanged_test.go
+++ b/internal/plugin/pathschanged_test.go
@@ -1,9 +1,0 @@
-package plugin
-
-import (
-	"testing"
-)
-
-func TestPathsChangedFulfillsPluginInterface(t *testing.T) {
-	_ = NewRouter("", WithConvertPlugins(NewPathsChanged()))
-}


### PR DESCRIPTION
This PR creates a new convert plugins directory and moves in the `pathschanged` plugin. This is just for organization and to provide a obvious place to store new plugins. It also removes an unnecessary test.